### PR TITLE
Add iostat listener, update dcgm listener

### DIFF
--- a/radt/radt/constants.py
+++ b/radt/radt/constants.py
@@ -25,7 +25,7 @@ COMMAND = (
     '-P params="-" '
 )
 
-RUN_LISTENERS = ["ps", "smi", "dcgmi", "top"]
+RUN_LISTENERS = ["ps", "smi", "dcgmi", "top", "iostat"]
 
 WORKLOAD_LISTENERS = {
     "nsys": "nsys profile --capture-range nvtx --nvtx-capture profile --cuda-memory-usage=true --capture-range-end repeat -o nsys_{Experiment}_{Workload}_{Letter} -f true -w true -x true -t cuda,nvtx ",

--- a/radt/radt/run/benchmark.py
+++ b/radt/radt/run/benchmark.py
@@ -5,7 +5,7 @@ from time import time
 from subprocess import PIPE, Popen
 import mlflow
 
-from .listeners import dcgmi_listener, ps_listener, smi_listener, top_listener
+from .listeners import dcgmi_listener, ps_listener, smi_listener, top_listener, iostat_listener
 
 
 def dummy(*args, **kwargs):
@@ -105,6 +105,9 @@ class RADTBenchmark:
         if os.getenv("RADT_LISTENER_TOP") == "True":
             os.environ["RADT_LISTENER_TOP"] = "False"
             self.threads.append(top_listener.TOPThread(self.run_id))
+        if os.getenv("RADT_LISTENER_IOSTAT") == "True":
+            os.environ["RADT_LISTENER_IOSTAT"] = "False"
+            self.threads.append(iostat_listener.IOstatThread(self.run_id))
 
         for thread in self.threads:
             thread.start()

--- a/radt/radt/run/listeners/dcgmi_listener.py
+++ b/radt/radt/run/listeners/dcgmi_listener.py
@@ -51,8 +51,7 @@ class DCGMIThread(Process):
         )
 
     def run(self):
-        idx = 0
-        while idx < len(self.dcgm_fields):
+        for idx, _ in enumerate(self.dcgm_fields):
             self._start_dcgm(idx)
 
             self.monitor()
@@ -60,8 +59,6 @@ class DCGMIThread(Process):
             # If advanced metrics are not available, restart the service with limited collection
             if "Error setting watches" not in str(self.dcgm.stderr.read()):
                 return
-
-            idx += 1
 
     def monitor(self):
         for line in io.TextIOWrapper(self.dcgm.stdout, encoding="utf-8"):

--- a/radt/radt/run/listeners/iostat_listener.py
+++ b/radt/radt/run/listeners/iostat_listener.py
@@ -1,0 +1,44 @@
+import mlflow
+import subprocess
+import io
+
+from multiprocessing import Process
+
+class IOstatThread(Process):
+    def __init__(self, run_id, experiment_id=88):
+        super(IOstatThread, self).__init__()
+        self.run_id = run_id
+        self.experiment_id = experiment_id
+
+    def run(self):
+        ps = subprocess.Popen(
+            "iostat 1 -m".split(),
+            stdout=subprocess.PIPE,
+        )
+
+        for line in io.TextIOWrapper(ps.stdout, encoding="utf-8"):
+            m = {}
+            line = line.lstrip()
+
+            if (
+                line.startswith("nvme")
+                or line.startswith("sd")
+            ):
+                word_vector = line.strip().split()
+
+                device = word_vector[0]         # storage device
+                mb_read_s = word_vector[2]      # MB read/s
+                mb_written_s = word_vector[3]   # MB wrtn/s
+                mb_discarded_s = word_vector[4] # MB dscd/s
+                mb_read = word_vector[5]        # MB read since last sample
+                mb_written = word_vector[6]     # MB written since last sample
+                mb_discarded = word_vector[7]   # MB discarded since last sample
+
+                m[f"{device} - MB read/s"] = float(mb_read_s)
+                m[f"{device} - MB written/s"] = float(mb_written_s)
+                # m[f"{device} - MB discarded/s"] = mb_discarded_s
+                m[f"{device} - MB read"] = float(mb_read)
+                m[f"{device} - MB written"] = float(mb_written)
+                # m[f"{device} - MB discarded"] = mb_discarded_s
+
+                mlflow.log_metrics(m)

--- a/radt/radt/schedule/schedule.py
+++ b/radt/radt/schedule/schedule.py
@@ -415,6 +415,9 @@ def remove_mps():
     """Remove MPS"""
     execute_command(["echo quit | nvidia-cuda-mps-control"], shell=True)
 
+def clear_page_cache():
+    """Clears OS page cache"""
+    execute_command(["sudo sh -c \"/bin/echo 3 > /proc/sys/vm/drop_caches\""], shell=True)
 
 def determine_operating_mode(
     parsed_args: Namespace, file: Path, args_passthrough: list
@@ -518,6 +521,7 @@ def start_schedule(parsed_args: Namespace, file: Path, args_passthrough: list):
 
         for i, row in df_workload.iterrows():
             remove_mps()
+            clear_page_cache()
 
             if "g" in str(row["Collocation"]):  # TODO: fix
                 result = migedit.make_mig_devices(


### PR DESCRIPTION
This PR adds `iostat` as an optional listener to radt.
The listener logs I/O bandwidth metrics for storage devices with either nvme or sd* prefixes.
A set of metrics is logged for each device, as well as a total sum over all devices.

The PR further changes the DCGM listener to fall back on hierarchies of metrics to be collected, since some machines only differ slightly in what metrics they support.